### PR TITLE
1.14 Cat Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,6 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                    <debug>true</debug>
-                    <showDeprecation>false</showDeprecation>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <debug>true</debug>
+                    <showDeprecation>false</showDeprecation>
                 </configuration>
             </plugin>
         </plugins>
@@ -47,7 +49,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/maxwellwheeler/plugins/tppets/storage/PetType.java
+++ b/src/main/java/com/maxwellwheeler/plugins/tppets/storage/PetType.java
@@ -13,7 +13,7 @@ import java.util.Hashtable;
 public class PetType {
     /*
      * Enum representing a pet type.
-     * CAT = ocelot
+     * CAT = cat
      * DOG = wolf
      * PARROT = parrot
      * UNKNOWN = a pet not of the above three types
@@ -26,7 +26,7 @@ public class PetType {
     
     static {
         classTranslate = new Hashtable<>();
-        classTranslate.put(Pets.CAT, new Class<?>[]{org.bukkit.entity.Ocelot.class});
+        classTranslate.put(Pets.CAT, new Class<?>[]{org.bukkit.entity.Cat.class});
         classTranslate.put(Pets.DOG, new Class<?>[]{org.bukkit.entity.Wolf.class});
         classTranslate.put(Pets.PARROT, new Class<?>[]{org.bukkit.entity.Parrot.class});
         classTranslate.put(Pets.MULE, new Class<?>[]{org.bukkit.entity.Mule.class});
@@ -43,7 +43,7 @@ public class PetType {
     public static Pets getEnumByEntity(Entity ent) {
         if (ent instanceof Wolf) {
             return Pets.DOG;
-        } else if (ent instanceof Ocelot) {
+        } else if (ent instanceof Cat) {
             return Pets.CAT;
         } else if (ent instanceof Parrot) {
             return Pets.PARROT;


### PR DESCRIPTION
TPPets doesn't work with new cats. We needed a fix on our server and this has worked for us.

We're working on our own solution internally for resolving any cats caught in registration-limbo for servers that updated to 1.14 before updating TPPets. This PR does not address any animals caught in that limbo, it simple makes sure that newly tamed cats are properly registered by TPPets.